### PR TITLE
Display instance name if window doesn't have a title

### DIFF
--- a/bspwm/bspwm_window_titles.sh
+++ b/bspwm/bspwm_window_titles.sh
@@ -46,6 +46,11 @@ bspc subscribe node_focus node_remove desktop_focus | while read -r _; do
                 # trim window name
                 window_name=$( echo "$window_name_short" | sed -e 's/^[[:space:]]*//' )
 
+                # display instance name if there is no window title
+                if [[ "$window_name" == "N/A" ]]; then
+                    window_name=$(echo "$window" | cut -d " " -f 3 | cut -d "." -f 2 )
+                fi
+
                 # get icon for class name
                 window_icon=$( grep "$window_class" <<< "$icon_map" | cut -d " " -f2 )
 


### PR DESCRIPTION
Some programs simply display "N/A" as the window title (ex. Steam) which makes the titles really useless. I think the instance name is more useful in those cases.